### PR TITLE
Fix auto-format GitHub action

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -4,8 +4,6 @@ name: auto-format
 # Controls when the action will run. 
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
-  push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 

--- a/src/interpreter.h
+++ b/src/interpreter.h
@@ -1,33 +1,30 @@
 #ifndef INTERPRETER_H
 #define INTERPRETER_H
 
-struct Question
-{
-    int hashq;              // stores the hash value of the question text
-    char * type;            // defaults to MCQ for version 1 (type = "MCQ")
-    char * text;            // has the text of the question
-    double difficulty;      // stores the difficulty level of the question (max = 1)
-    int no_options;         // stores the number of options for the question
-    char ** options;        // contains the options in an array of strings
-    char * correct_option;  // stores the correct option of the question
+struct Question {
+	int hashq;		   // stores the hash value of the question text
+	char *type;		   // defaults to MCQ for version 1 (type = "MCQ")
+	char *text;		   // has the text of the question
+	double difficulty; // stores the difficulty level of the question (max = 1)
+	int no_options;	   // stores the number of options for the question
+	char **options;	   // contains the options in an array of strings
+	char *correct_option; // stores the correct option of the question
 };
 
 typedef struct Question Question;
 
-struct Question_Bank
-{
-    int no_questions;       // stores the number of questions in this question bank
-    Question ** questions;  // Array of pointers to "struct Question pointers"
+struct Question_Bank {
+	int no_questions; // stores the number of questions in this question bank
+	Question **questions; // Array of pointers to "struct Question pointers"
 };
 
 typedef struct Question_Bank Question_Bank;
 
-struct User_Parameters
-{
-    char * type;                // defaults to MCQ for version 1 (type = "MCQ")
-    double difficulty;          // difficulty level which the user requires
-    int no_questions;           // number of questions which the user needs
-    char comparator[2];         // can be "==", "<", "<=", ">", ">="
+struct User_Parameters {
+	char *type;			// defaults to MCQ for version 1 (type = "MCQ")
+	double difficulty;	// difficulty level which the user requires
+	int no_questions;	// number of questions which the user needs
+	char comparator[2]; // can be "==", "<", "<=", ">", ">="
 };
 
 typedef struct User_Parameters User_Parameters;


### PR DESCRIPTION
Previously, the action was also triggered on pushes to the `master` branch. This is undesirable because the
master branch is restricted, so the formatting commits cannot be pushed by it.